### PR TITLE
More flexible way to activate event sources

### DIFF
--- a/src/Clients/HotChocolate.Tests/HotChocolate.Tests.csproj
+++ b/src/Clients/HotChocolate.Tests/HotChocolate.Tests.csproj
@@ -62,6 +62,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Core\Core.Abstractions\Core.Abstractions.csproj" />
     <ProjectReference Include="..\..\Core\Session\Session.csproj" />
     <ProjectReference Include="..\..\Core\Transmission.BlobStorage\Transmission.BlobStorage.csproj" />
     <ProjectReference Include="..\..\Core\Transmission.EventHub\Transmission.EventHub.csproj" />

--- a/src/Clients/HotChocolate.Tests/TestStartupFilter.cs
+++ b/src/Clients/HotChocolate.Tests/TestStartupFilter.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Thor.Core.Session.Abstractions;
+
+namespace Thor.HotChocolate.Tests
+{
+    public class TestStartupFilter : IStartupFilter
+    {
+        public Action<IApplicationBuilder> Configure(
+            Action<IApplicationBuilder> next)
+        {
+            return builder =>
+            {
+                builder
+                    .ApplicationServices
+                    .GetService<ITelemetrySession>()
+                    .Attach(ProbeTransmitter.Instance);
+
+                next(builder);
+            };
+        }
+    }
+}

--- a/src/Clients/HotChocolate/EventSourceNames.cs
+++ b/src/Clients/HotChocolate/EventSourceNames.cs
@@ -1,0 +1,7 @@
+﻿namespace Thor.HotChocolate
+{
+    internal static class EventSourceNames
+    {
+        public const string HotChocolate = "ChilliCream-HotChocolate";
+    }
+}

--- a/src/Clients/HotChocolate/HotChocolateActivityEventSource.cs
+++ b/src/Clients/HotChocolate/HotChocolateActivityEventSource.cs
@@ -7,7 +7,7 @@ using Thor.Core.Transmission.Abstractions;
 
 namespace Thor.HotChocolate
 {
-    [EventSource(Name = "ChilliCream-HotChocolate")]
+    [EventSource(Name = EventSourceNames.HotChocolate)]
     internal sealed class HotChocolateActivityEventSource
         : EventSourceBase
     {

--- a/src/Clients/HotChocolate/HotChocolateProvidersDescriptor.cs
+++ b/src/Clients/HotChocolate/HotChocolateProvidersDescriptor.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+using Thor.Core.Abstractions;
+
+namespace Thor.HotChocolate
+{
+    /// <summary>
+    /// HotChocolate event sources location
+    /// </summary>
+    public class HotChocolateProvidersDescriptor : IProvidersDescriptor
+    {
+        /// <inheritdoc cref="IProvidersDescriptor"/>
+        public IEnumerable<string> Assemblies { get; } =
+            new[] {typeof(HotChocolateProvidersDescriptor).Assembly.FullName};
+    }
+}

--- a/src/Clients/HotChocolate/ServiceCollectionExtensions.cs
+++ b/src/Clients/HotChocolate/ServiceCollectionExtensions.cs
@@ -31,8 +31,10 @@ namespace Thor.HotChocolate
             }
 
             return services
-                .AddSingleton<IDiagnosticsListener, HotChocolateDiagnosticsListener>()
-                .AddSingleton<IProvidersDescriptor, HotChocolateProvidersDescriptor>();
+                .AddSingleton<IDiagnosticsListener,
+                    HotChocolateDiagnosticsListener>()
+                .AddSingleton<IProvidersDescriptor,
+                    HotChocolateProvidersDescriptor>();
         }
     }
 }

--- a/src/Clients/HotChocolate/ServiceCollectionExtensions.cs
+++ b/src/Clients/HotChocolate/ServiceCollectionExtensions.cs
@@ -31,7 +31,8 @@ namespace Thor.HotChocolate
             }
 
             return services
-                .AddSingleton<IDiagnosticsListener, HotChocolateDiagnosticsListener>();
+                .AddSingleton<IDiagnosticsListener, HotChocolateDiagnosticsListener>()
+                .AddSingleton<IProvidersDescriptor, HotChocolateProvidersDescriptor>();
         }
     }
 }

--- a/src/Clients/Http/HttpProvidersDescriptor.cs
+++ b/src/Clients/Http/HttpProvidersDescriptor.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+using Thor.Core.Abstractions;
+
+namespace Thor.Core.Http
+{
+    /// <summary>
+    /// Http event sources location
+    /// </summary>
+    public class HttpProvidersDescriptor : IProvidersDescriptor
+    {
+        /// <inheritdoc cref="IProvidersDescriptor"/>
+        public IEnumerable<string> Assemblies { get; } =
+            new[] {typeof(HttpProvidersDescriptor).Assembly.FullName};
+    }
+}

--- a/src/Clients/Http/ServiceCollectionExtensions.cs
+++ b/src/Clients/Http/ServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Http;
+using Thor.Core.Abstractions;
 
 namespace Thor.Core.Http
 {
@@ -45,7 +46,8 @@ namespace Thor.Core.Http
 
             return services
                 .AddTracingCore(configuration)
-                .AddHttpClient();
+                .AddHttpClient()
+                .AddSingleton<IProvidersDescriptor, HttpProvidersDescriptor>();
         }
     }
 }

--- a/src/Core/Core.Abstractions/IProvidersDescriptor.cs
+++ b/src/Core/Core.Abstractions/IProvidersDescriptor.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+
+namespace Thor.Core.Abstractions
+{
+    /// <summary>
+    /// Describe assemblies in where are event sources.
+    /// </summary>
+    public interface IProvidersDescriptor
+    {
+        /// <summary>
+        /// List with assembly full name
+        /// </summary>
+        IEnumerable<string> Assemblies { get; }
+    }
+}

--- a/src/Core/Core/CoreProvidersDescriptor.cs
+++ b/src/Core/Core/CoreProvidersDescriptor.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+using Thor.Core.Abstractions;
+
+namespace Thor.Core
+{
+    /// <summary>
+    /// Core event sources location
+    /// </summary>
+    public class CoreProvidersDescriptor : IProvidersDescriptor
+    {
+        /// <inheritdoc cref="IProvidersDescriptor"/>
+        public IEnumerable<string> Assemblies { get; } =
+            new[] {typeof(CoreProvidersDescriptor).Assembly.FullName};
+    }
+}

--- a/src/Core/Core/ServiceCollectionExtensions.cs
+++ b/src/Core/Core/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Thor.Core.Abstractions;
 
 namespace Thor.Core
 {
@@ -36,6 +37,7 @@ namespace Thor.Core
             }
 
             return services
+                .AddSingleton<IProvidersDescriptor, CoreProvidersDescriptor>()
                 .AddOptions()
                 .Configure<TracingConfiguration>(configuration
                     .GetSection("Tracing"));

--- a/src/Core/Session.Abstractions/ProbeTransmitter.cs
+++ b/src/Core/Session.Abstractions/ProbeTransmitter.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Concurrent;
+using System.Linq;
 using Thor.Core.Abstractions;
 using Thor.Core.Transmission.Abstractions;
 
@@ -13,16 +14,37 @@ namespace Thor.Core.Session.Abstractions
     public class ProbeTransmitter
         : ITelemetryEventTransmitter
     {
+        /// <summary>
+        /// Static instance of <see cref="ProbeTransmitter"/>
+        /// </summary>
+        public static ProbeTransmitter Instance { get; } =
+            new ProbeTransmitter();
+
         private readonly ConcurrentQueue<TelemetryEvent> _queue =
             new ConcurrentQueue<TelemetryEvent>();
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Number of cached <see cref="TelemetryEvent"/>
+        /// </summary>
         public int Count { get { return _queue.Count; } }
 
         /// <inheritdoc/>
         public void Enqueue(TelemetryEvent data)
         {
             _queue.Enqueue(data);
+        }
+
+        /// <summary>
+        /// Check if the transmitter has received specific event.
+        /// </summary>
+        /// <param name="providerName">The provider name</param>
+        /// <param name="eventName">The event name</param>
+        /// <returns></returns>
+        public bool Contains(string providerName, string eventName)
+        {
+            return _queue.Any(telemetryEvent =>
+                telemetryEvent.ProviderName == providerName &&
+                telemetryEvent.Name == eventName);
         }
 
         /// <summary>

--- a/src/Core/Session.Tests/InProcessTelemetrySessionTests.cs
+++ b/src/Core/Session.Tests/InProcessTelemetrySessionTests.cs
@@ -38,30 +38,6 @@ namespace Thor.Core.Session.Tests
             Assert.Null(Record.Exception(verify));
         }
 
-        [Fact(DisplayName = "Create: Should have enabled default event providers if referenced")]
-        public void Create_VerifyDefaultProviders()
-        {
-            // arrange
-            int applicationId = 1;
-            ProbeTransmitter transmitter = new ProbeTransmitter();
-
-            // act
-            int telemetryCount = 0;
-
-            using (ITelemetrySession session = InProcessTelemetrySession
-                .Create(applicationId, EventLevel.Verbose))
-            {
-                session.Attach(transmitter);
-                Application.Start(applicationId);
-                Custom.EventSources.TestEventSource.Log.RunProcess(1234);
-                Application.Stop();
-                telemetryCount = transmitter.Count;
-            }
-
-            // assert
-            Assert.Equal(2, telemetryCount);
-        }
-
         [Fact(DisplayName = "Create: Should have enabled default event providers plus those who where allowed if referenced")]
         public void Create_VerifyDefaultAndAllowedProviders()
         {
@@ -84,7 +60,7 @@ namespace Thor.Core.Session.Tests
             }
 
             // assert
-            Assert.Equal(3, telemetryCount);
+            Assert.Equal(1, telemetryCount);
         }
 
         private class TestProviderDescriptor : IProvidersDescriptor

--- a/src/Core/Session.Tests/InProcessTelemetrySessionTests.cs
+++ b/src/Core/Session.Tests/InProcessTelemetrySessionTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.Tracing;
+using Thor.Core.Abstractions;
 using Thor.Core.Session.Abstractions;
 using Thor.Core.Transmission.Abstractions;
 using Xunit;
@@ -72,7 +74,7 @@ namespace Thor.Core.Session.Tests
 
             using (ITelemetrySession session = InProcessTelemetrySession
                 .Create(applicationId, EventLevel.Verbose,
-                    new[] { "Custom" }))
+                    new[] { new TestProviderDescriptor() }))
             {
                 session.Attach(transmitter);
                 Application.Start(applicationId);
@@ -83,6 +85,12 @@ namespace Thor.Core.Session.Tests
 
             // assert
             Assert.Equal(3, telemetryCount);
+        }
+
+        private class TestProviderDescriptor : IProvidersDescriptor
+        {
+            public IEnumerable<string> Assemblies { get; } =
+                new[] {"Custom"};
         }
 
         #endregion

--- a/src/Core/Session/InProcessTelemetrySession.cs
+++ b/src/Core/Session/InProcessTelemetrySession.cs
@@ -23,7 +23,8 @@ namespace Thor.Core.Session
         : EventListener
             , ITelemetrySession
     {
-        private readonly ImmutableHashSet<string> _allowedPrefixes;
+        private readonly ImmutableHashSet<string> _allowedPrefixes =
+            ImmutableHashSet<string>.Empty;
         private static readonly Type _attributeType =
             typeof(EventSourceAttribute);
         private static readonly Type _baseType = typeof(EventSource);
@@ -45,7 +46,6 @@ namespace Thor.Core.Session
                     ExceptionMessages.ApplicationIdMustBeGreaterZero);
             }
 
-            _allowedPrefixes = ImmutableHashSet.Create("Thor.Core");
             _currentDomain = AppDomain.CurrentDomain;
             _sessionName = SessionNameProvider.Create(applicationId);
             _level = level;

--- a/src/Core/Session/InProcessTelemetrySession.cs
+++ b/src/Core/Session/InProcessTelemetrySession.cs
@@ -21,7 +21,7 @@ namespace Thor.Core.Session
     /// </summary>
     public class InProcessTelemetrySession
         : EventListener
-            , ITelemetrySession
+        , ITelemetrySession
     {
         private readonly ImmutableHashSet<string> _allowedPrefixes =
             ImmutableHashSet<string>.Empty;

--- a/src/Core/Session/InProcessTelemetrySession.cs
+++ b/src/Core/Session/InProcessTelemetrySession.cs
@@ -106,10 +106,10 @@ namespace Thor.Core.Session
         private static bool IsAssignableFrom(Type type)
         {
             return type.IsClass && type != _baseType && _baseType.IsAssignableFrom(type) &&
-                   type.CustomAttributes.Count(a => a.AttributeType == _attributeType) == 1 &&
-                   type.CustomAttributes.First(a => a.AttributeType == _attributeType)
-                       .NamedArguments.Count(a => a.MemberName == "Name" &&
-                            !string.IsNullOrWhiteSpace((string)a.TypedValue.Value)) == 1;
+               type.CustomAttributes.Count(a => a.AttributeType == _attributeType) == 1 &&
+               type.CustomAttributes.First(a => a.AttributeType == _attributeType)
+                   .NamedArguments.Count(a => a.MemberName == "Name" &&
+                        !string.IsNullOrWhiteSpace((string)a.TypedValue.Value)) == 1;
         }
 
         private static Dictionary<string, Type> CreateProviderNameMap(

--- a/src/Core/Session/InProcessTelemetrySession.cs
+++ b/src/Core/Session/InProcessTelemetrySession.cs
@@ -313,7 +313,7 @@ namespace Thor.Core.Session
         public static InProcessTelemetrySession Create(int applicationId,
             EventLevel level)
         {
-            return Create(applicationId, level, null);
+            return Create(applicationId, level, Enumerable.Empty<IProvidersDescriptor>());
         }
 
         /// <summary>
@@ -345,14 +345,18 @@ namespace Thor.Core.Session
         /// <param name="configuration">
         /// A session configuration instance.
         /// </param>
+        /// <param name="providersDescriptors">
+        /// A collection of provider descriptors.
+        /// </param>
         /// <returns>
         /// A new instance of <see cref="InProcessTelemetrySession"/>.
         /// </returns>
         public static InProcessTelemetrySession Create(
-            SessionConfiguration configuration)
+            SessionConfiguration configuration,
+            IEnumerable<IProvidersDescriptor> providersDescriptors)
         {
             return Create(configuration.ApplicationId, configuration.Level,
-                configuration.AllowedPrefixes);
+                providersDescriptors);
         }
 
         #endregion

--- a/src/Core/Session/InProcessTelemetrySession.cs
+++ b/src/Core/Session/InProcessTelemetrySession.cs
@@ -106,9 +106,9 @@ namespace Thor.Core.Session
         private static bool IsAssignableFrom(Type type)
         {
             return type.IsClass && type != _baseType && _baseType.IsAssignableFrom(type) &&
-               type.CustomAttributes.Count(a => a.AttributeType == _attributeType) == 1 &&
-               type.CustomAttributes.First(a => a.AttributeType == _attributeType)
-                   .NamedArguments.Count(a => a.MemberName == "Name" &&
+                type.CustomAttributes.Count(a => a.AttributeType == _attributeType) == 1 &&
+                type.CustomAttributes.First(a => a.AttributeType == _attributeType)
+                    .NamedArguments.Count(a => a.MemberName == "Name" &&
                         !string.IsNullOrWhiteSpace((string)a.TypedValue.Value)) == 1;
         }
 

--- a/src/Core/Session/ServiceCollectionExtensions.cs
+++ b/src/Core/Session/ServiceCollectionExtensions.cs
@@ -37,6 +37,7 @@ namespace Thor.Core.Session
             return services
                 .AddTracingCore(configuration)
                 .Configure<SessionConfiguration>(configuration.GetSection("Tracing"))
+                .AddSingleton<IProvidersDescriptor, SessionConfigurationProvidersDescriptor>()
                 .AddSingleton(p =>
                 {
                     SessionConfiguration config = p

--- a/src/Core/Session/ServiceCollectionExtensions.cs
+++ b/src/Core/Session/ServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Thor.Core.Abstractions;
 using Thor.Core.Session.Abstractions;
 using Thor.Core.Transmission.Abstractions;
 
@@ -43,7 +44,7 @@ namespace Thor.Core.Session
                     IEnumerable<ITelemetryEventTransmitter> eventTransmitters =
                         p.GetServices<ITelemetryEventTransmitter>();
                     ITelemetrySession session = InProcessTelemetrySession
-                        .Create(config);
+                        .Create(config, p.GetServices<IProvidersDescriptor>());
 
                     foreach (ITelemetryEventTransmitter transmitter in eventTransmitters)
                     {

--- a/src/Core/Session/SessionConfiguration.cs
+++ b/src/Core/Session/SessionConfiguration.cs
@@ -8,9 +8,9 @@ namespace Thor.Core.Session
     /// </summary>
     public class SessionConfiguration
     {
-        /// <summary>	
-        /// Gets or sets allowed assembly name prefixes.	
-        /// </summary>	
+        /// <summary>
+        /// Gets or sets allowed assembly name prefixes.
+        /// </summary>
         public IEnumerable<string> AllowedPrefixes { get; set; }
 
         /// <summary>

--- a/src/Core/Session/SessionConfiguration.cs
+++ b/src/Core/Session/SessionConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.Tracing;
+﻿using System.Collections.Generic;
+using System.Diagnostics.Tracing;
 
 namespace Thor.Core.Session
 {
@@ -7,6 +8,11 @@ namespace Thor.Core.Session
     /// </summary>
     public class SessionConfiguration
     {
+        /// <summary>	
+        /// Gets or sets allowed assembly name prefixes.	
+        /// </summary>	
+        public IEnumerable<string> AllowedPrefixes { get; set; }
+
         /// <summary>
         /// Gets or sets the application's identifier.
         /// </summary>

--- a/src/Core/Session/SessionConfiguration.cs
+++ b/src/Core/Session/SessionConfiguration.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Diagnostics.Tracing;
+﻿using System.Diagnostics.Tracing;
 
 namespace Thor.Core.Session
 {
@@ -8,11 +7,6 @@ namespace Thor.Core.Session
     /// </summary>
     public class SessionConfiguration
     {
-        /// <summary>
-        /// Gets or sets allowed assembly name prefixes.
-        /// </summary>
-        public IEnumerable<string> AllowedPrefixes { get; set; }
-
         /// <summary>
         /// Gets or sets the application's identifier.
         /// </summary>

--- a/src/Core/Session/SessionConfigurationProvidersDescriptor.cs
+++ b/src/Core/Session/SessionConfigurationProvidersDescriptor.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Options;
+using Thor.Core.Abstractions;
+
+namespace Thor.Core.Session
+{
+    /// <summary>
+    /// Event sources location from configuration
+    /// </summary>
+    public class SessionConfigurationProvidersDescriptor : IProvidersDescriptor
+    {
+        /// <summary>
+        /// Creates a SessionConfigurationProvidersDescriptor
+        /// </summary>
+        /// <param name="sessionConfiguration"></param>
+        public SessionConfigurationProvidersDescriptor(
+            IOptions<SessionConfiguration> sessionConfiguration)
+        {
+            if (sessionConfiguration == null)
+            {
+                throw new ArgumentNullException(nameof(sessionConfiguration));
+            }
+
+            Assemblies = sessionConfiguration.Value.AllowedPrefixes ??
+                Enumerable.Empty<string>();
+        }
+
+        /// <inheritdoc cref="IProvidersDescriptor"/>
+        public IEnumerable<string> Assemblies { get; }
+    }
+}

--- a/src/Core/Session/SessionConfigurationProvidersDescriptor.cs
+++ b/src/Core/Session/SessionConfigurationProvidersDescriptor.cs
@@ -12,9 +12,11 @@ namespace Thor.Core.Session
     public class SessionConfigurationProvidersDescriptor : IProvidersDescriptor
     {
         /// <summary>
-        /// Creates a SessionConfigurationProvidersDescriptor
+        /// Creates a new instance of <see cref="SessionConfigurationProvidersDescriptor"/>
         /// </summary>
-        /// <param name="sessionConfiguration"></param>
+        /// <param name="sessionConfiguration">
+        /// Configuration for the telemetry event session.
+        /// </param>
         public SessionConfigurationProvidersDescriptor(
             IOptions<SessionConfiguration> sessionConfiguration)
         {


### PR DESCRIPTION
Replace "allowedPrefixes" with an abstraction which can be registered over DI-container