### PR TITLE
Add skip request filter for http diagnostics listener

### DIFF
--- a/src/Clients/AspNetCore.Tests/AspNetCore.Tests.csproj
+++ b/src/Clients/AspNetCore.Tests/AspNetCore.Tests.csproj
@@ -26,7 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Core\Core\Core.csproj" />
     <ProjectReference Include="..\AspNetCore\AspNetCore.csproj" />
+    <ProjectReference Include="..\Http\Http.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Clients/AspNetCore.Tests/HostingDiagnosticListenerTests.cs
+++ b/src/Clients/AspNetCore.Tests/HostingDiagnosticListenerTests.cs
@@ -1,0 +1,70 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.Threading.Tasks;
+using Thor.Core;
+using Thor.Core.Session.Abstractions;
+using Thor.Extensions.Http;
+using Xunit;
+
+namespace Thor.Hosting.AspNetCore.Tests
+{
+    public class HostingDiagnosticListenerTests
+    {
+        [Fact]
+        public async Task CreateRequest_WhenSkipRequestIsEmpty_TriggerEvents()
+        {
+            var configuration = new Dictionary<string, string>
+            {
+                {"Tracing:ApplicationId", "999"},
+                {"Tracing:SkipRequestFilter", ""}
+            };
+
+            await RequestActivityEventSource.Log.ListenAsync(async listener =>
+            {
+                using var context = new TestServerContext(configuration);
+                await context.Client.GetAsync("/get");
+
+                Assert.Collection(listener.OrderedEvents,
+                    startEvent => Assert.Equal(EventOpcode.Start, startEvent.Opcode),
+                    stopEvent => Assert.Equal(EventOpcode.Stop, stopEvent.Opcode));
+            });
+        }
+
+        [Fact]
+        public async Task CreateRequest_WhenSkipRequestHasValue_NoEventsAreTriggered()
+        {
+            var configuration = new Dictionary<string, string>
+            {
+                {"Tracing:ApplicationId", "999"},
+                {"Tracing:SkipRequestFilter", "_health"}
+            };
+
+            await RequestActivityEventSource.Log.ListenAsync(async listener =>
+            {
+                using var context = new TestServerContext(configuration);
+                await context.Client.GetAsync("/_health/readyness");
+
+                Assert.Empty(listener.OrderedEvents);
+            });
+        }
+
+        [Fact]
+        public async Task CreateRequest_WhenSkipRequestHasValueAndThrowsException_TriggerEventS()
+        {
+            var configuration = new Dictionary<string, string>
+            {
+                {"Tracing:ApplicationId", "999"},
+                {"Tracing:SkipRequestFilter", "_health"}
+            };
+
+            await ApplicationEventSource.Log.ListenAsync(async listener =>
+            {
+                using var context = new TestServerContext(configuration);
+                await context.Client.GetAsync("/_health/liveness");
+
+                Assert.Collection(listener.OrderedEvents,
+                    errorEvent => Assert.Equal(EventLevel.Error, errorEvent.Level));
+            });
+        }
+    }
+}

--- a/src/Clients/AspNetCore.Tests/TestServerContext.cs
+++ b/src/Clients/AspNetCore.Tests/TestServerContext.cs
@@ -1,16 +1,22 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
 
 namespace Thor.Hosting.AspNetCore.Tests
 {
     public class TestServerContext
         : IDisposable
     {
-        public TestServerContext()
+        public TestServerContext(IEnumerable<KeyValuePair<string, string>> configuration)
         {
-            Server = new TestServer(new WebHostBuilder().UseStartup<TestServerStartup>());
+            var webHostBuilder = new WebHostBuilder()
+                .ConfigureAppConfiguration(c => c.AddInMemoryCollection(configuration))
+                .UseStartup<TestServerStartup>();
+
+            Server = new TestServer(webHostBuilder);
             Client = Server.CreateClient();
         }
 

--- a/src/Clients/AspNetCore/HostingDiagnosticsListener.cs
+++ b/src/Clients/AspNetCore/HostingDiagnosticsListener.cs
@@ -14,10 +14,13 @@ namespace Thor.Hosting.AspNetCore
 
         public HostingDiagnosticsListener(string skipRequestFilterPattern)
         {
-            _skipRequestFilter = new Regex(
-                skipRequestFilterPattern,
-                RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
-        }   
+            if (skipRequestFilterPattern is { })
+            {
+                _skipRequestFilter = new Regex(
+                    skipRequestFilterPattern,
+                    RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+            }
+        }
 
         [DiagnosticName("Microsoft.AspNetCore.Diagnostics.HandledException")]
         public void OnDiagnosticsHandledException(HttpContext httpContext, Exception exception)
@@ -47,7 +50,8 @@ namespace Thor.Hosting.AspNetCore
         public void OnHttpRequestInStart(HttpContext httpContext)
         {
             Uri requestUri = new Uri(httpContext.Request.GetDisplayUrl());
-            if (_skipRequestFilter.IsMatch(requestUri.AbsoluteUri))
+            if (_skipRequestFilter is { } &&
+                _skipRequestFilter.IsMatch(requestUri.AbsoluteUri))
             {
                 return;
             }

--- a/src/Clients/AspNetCore/HostingDiagnosticsListener.cs
+++ b/src/Clients/AspNetCore/HostingDiagnosticsListener.cs
@@ -14,7 +14,7 @@ namespace Thor.Hosting.AspNetCore
 
         public HostingDiagnosticsListener(string skipRequestFilterPattern)
         {
-            if (skipRequestFilterPattern is { })
+            if (!string.IsNullOrEmpty(skipRequestFilterPattern))
             {
                 _skipRequestFilter = new Regex(
                     skipRequestFilterPattern,

--- a/src/Clients/AspNetCore/HostingDiagnosticsListener.cs
+++ b/src/Clients/AspNetCore/HostingDiagnosticsListener.cs
@@ -16,9 +16,10 @@ namespace Thor.Hosting.AspNetCore
         {
             if (!string.IsNullOrEmpty(skipRequestFilterPattern))
             {
-                _skipRequestFilter = new Regex(
-                    skipRequestFilterPattern,
-                    RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+                _skipRequestFilter = new Regex(skipRequestFilterPattern,
+                    RegexOptions.Compiled |
+                    RegexOptions.CultureInvariant |
+                    RegexOptions.IgnoreCase);
             }
         }
 

--- a/src/Clients/AspNetCore/TracingStartupFilter.cs
+++ b/src/Clients/AspNetCore/TracingStartupFilter.cs
@@ -27,7 +27,8 @@ namespace Thor.Hosting.AspNetCore
         /// <param name="configurationAccessor">A configuration accessor instance.</param>
         /// <param name="initializer">An attachment transmission initializer.</param>
         /// <param name="session">An optional telemetry event session.</param>
-        public TracingStartupFilter(IApplicationLifetime applicationLifetime,
+        public TracingStartupFilter(
+            IApplicationLifetime applicationLifetime,
             IOptions<TracingConfiguration> configurationAccessor,
             IAttachmentTransmissionInitializer initializer,
             ITelemetrySession session)
@@ -68,7 +69,7 @@ namespace Thor.Hosting.AspNetCore
                 builder
                     .ApplicationServices
                     .GetRequiredService<DiagnosticListener>()
-                    .SubscribeWithAdapter(new HostingDiagnosticsListener());
+                    .SubscribeWithAdapter(new HostingDiagnosticsListener(_configurationAccessor.Value.SkipRequestFilter));
 
                 next(builder);
             };

--- a/src/Clients/Http/AssemblyAttributes.cs
+++ b/src/Clients/Http/AssemblyAttributes.cs
@@ -2,3 +2,4 @@
 
 [assembly:InternalsVisibleTo("Thor.Extensions.Http.Tests")]
 [assembly:InternalsVisibleTo("Thor.Extensions.HotChocoloate.Tests")]
+[assembly:InternalsVisibleTo("Thor.Hosting.AspNetCore.Tests")]

--- a/src/Core/Core/AssemblyAttributes.cs
+++ b/src/Core/Core/AssemblyAttributes.cs
@@ -4,3 +4,4 @@
 [assembly:InternalsVisibleTo("Thor.Core.Http.Tests")]
 [assembly:InternalsVisibleTo("Thor.Extensions.HotChocolate.Tests")]
 [assembly:InternalsVisibleTo("Thor.Extensions.Hosting.Tests")]
+[assembly:InternalsVisibleTo("Thor.Hosting.AspNetCore.Tests")]

--- a/src/Core/Core/ServiceCollectionExtensions.cs
+++ b/src/Core/Core/ServiceCollectionExtensions.cs
@@ -39,8 +39,7 @@ namespace Thor.Core
             return services
                 .AddSingleton<IProvidersDescriptor, CoreProvidersDescriptor>()
                 .AddOptions()
-                .Configure<TracingConfiguration>(configuration
-                    .GetSection("Tracing"));
+                .Configure<TracingConfiguration>(configuration.GetSection("Tracing"));
         }
     }
 }

--- a/src/Core/Core/TracingConfiguration.cs
+++ b/src/Core/Core/TracingConfiguration.cs
@@ -17,7 +17,6 @@ namespace Thor.Core
             Debug = Debugger.IsAttached;
             InProcess = true;
             Enabled = true;
-            SkipRequestFilter = "\0(?<!\0)";
         }
 
         /// <summary>

--- a/src/Core/Core/TracingConfiguration.cs
+++ b/src/Core/Core/TracingConfiguration.cs
@@ -17,7 +17,14 @@ namespace Thor.Core
             Debug = Debugger.IsAttached;
             InProcess = true;
             Enabled = true;
+            SkipRequestFilter = "\0(?<!\0)";
         }
+
+        /// <summary>
+        /// Gets or sets the request filter (regex which filter server requests).
+        /// The default value will allow all requests.
+        /// </summary>
+        public string SkipRequestFilter { get; set; }
 
         /// <summary>
         /// Gets or sets the application's identifier.

--- a/src/Core/Session.Abstractions/EventSourceExtensions.cs
+++ b/src/Core/Session.Abstractions/EventSourceExtensions.cs
@@ -52,6 +52,7 @@ namespace Thor.Core.Session.Abstractions
                     listener.EnableEvents(eventSource, EventLevel.Verbose);
                     await execute(listener);
                 }
+                catch { }
                 finally
                 {
                     listener.DisableEvents(eventSource);

--- a/src/Package.props
+++ b/src/Package.props
@@ -18,6 +18,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
  <ItemGroup>


### PR DESCRIPTION
Give the possibility to skip creating server activities by using a regex pattern, useful by health checks